### PR TITLE
Add Datta components and dark theme

### DIFF
--- a/src/renderer/components/common/DattaAuditTrail.jsx
+++ b/src/renderer/components/common/DattaAuditTrail.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export default function DattaAuditTrail({ entries = [] }) {
+  return (
+    <ul className="list-group">
+      {entries.map((entry, idx) => (
+        <li key={idx} className="list-group-item d-flex justify-content-between">
+          <span>{entry.action}</span>
+          <small className="text-muted">{entry.date}</small>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/renderer/components/common/DattaAutoSaveForm.jsx
+++ b/src/renderer/components/common/DattaAutoSaveForm.jsx
@@ -1,0 +1,60 @@
+import React, { useEffect, useState } from 'react';
+import DattaAlert from './DattaAlert';
+
+export default function DattaAutoSaveForm({ data, onSave, onError, saveInterval = 30000, children }) {
+  const [lastSaved, setLastSaved] = useState(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveStatus, setSaveStatus] = useState('saved');
+
+  useEffect(() => {
+    const interval = setInterval(async () => {
+      if (saveStatus === 'modified') {
+        setIsSaving(true);
+        try {
+          await onSave(data);
+          setLastSaved(new Date());
+          setSaveStatus('saved');
+        } catch (error) {
+          setSaveStatus('error');
+          onError?.(error);
+        } finally {
+          setIsSaving(false);
+        }
+      }
+    }, saveInterval);
+
+    return () => clearInterval(interval);
+  }, [data, saveInterval, saveStatus]);
+
+  const getStatusBadge = () => {
+    switch (saveStatus) {
+      case 'saved':
+        return <span className="badge bg-success">Sauvegarde</span>;
+      case 'modified':
+        return <span className="badge bg-warning">Non sauvegarde</span>;
+      case 'error':
+        return <span className="badge bg-danger">Erreur sauvegarde</span>;
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div>
+      <div className="d-flex justify-content-between align-items-center mb-3">
+        <div className="d-flex align-items-center gap-2">
+          {isSaving && <div className="spinner-border spinner-border-sm" role="status"></div>}
+          {getStatusBadge()}
+          {lastSaved && <small className="text-muted">Derniere sauvegarde: {lastSaved.toLocaleTimeString()}</small>}
+        </div>
+      </div>
+      {saveStatus === 'error' && (
+        <DattaAlert type="danger" className="mb-3">
+          <i className="feather icon-alert-circle me-2"></i>
+          Impossible de sauvegarder. Verifiez votre connexion reseau.
+        </DattaAlert>
+      )}
+      {children}
+    </div>
+  );
+}

--- a/src/renderer/components/common/DattaBackupStatus.jsx
+++ b/src/renderer/components/common/DattaBackupStatus.jsx
@@ -1,0 +1,24 @@
+export default function DattaBackupStatus({ lastBackup, nextBackup, isBackingUp }) {
+  return (
+    <div className="card">
+      <div className="card-body">
+        <div className="d-flex align-items-center">
+          <div className="avtar avtar-s bg-light-success me-3">
+            <i className={`feather ${isBackingUp ? 'icon-download' : 'icon-shield'}`}></i>
+          </div>
+          <div>
+            <h6 className="mb-1">Sauvegarde automatique</h6>
+            <p className="mb-0 text-muted">
+              {isBackingUp ? 'Sauvegarde en cours...' : `Derniere: ${lastBackup}`}
+            </p>
+          </div>
+        </div>
+        {isBackingUp && (
+          <div className="progress mt-2">
+            <div className="progress-bar progress-bar-striped progress-bar-animated" style={{ width: '100%' }}></div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/common/DattaConflictModal.jsx
+++ b/src/renderer/components/common/DattaConflictModal.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import DattaModal from './DattaModal';
+import DattaButton from './DattaButton';
+import DattaAlert from './DattaAlert';
+
+export default function DattaConflictModal({ conflicts, onResolve, onClose }) {
+  return (
+    <DattaModal open title="Conflit detecte" size="lg" onClose={onClose}>
+      <DattaAlert type="warning">
+        <i className="feather icon-alert-triangle me-2"></i>
+        Un autre utilisateur a modifie ces donnees simultanement.
+      </DattaAlert>
+      <div className="row">
+        <div className="col-md-6">
+          <div className="card">
+            <div className="card-header">
+              <h6><i className="feather icon-user me-2"></i>Vos modifications</h6>
+            </div>
+            <div className="card-body">
+              {/* Afficher les changements locaux */}
+            </div>
+          </div>
+        </div>
+        <div className="col-md-6">
+          <div className="card">
+            <div className="card-header">
+              <h6><i className="feather icon-users me-2"></i>Modifications distantes</h6>
+            </div>
+            <div className="card-body">
+              {/* Afficher les changements distants */}
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="d-flex justify-content-end gap-2 mt-3">
+        <DattaButton variant="secondary" onClick={onClose}>Annuler</DattaButton>
+        <DattaButton variant="primary" onClick={() => onResolve('local')}>Garder mes modifications</DattaButton>
+        <DattaButton variant="warning" onClick={() => onResolve('remote')}>Garder les modifications distantes</DattaButton>
+      </div>
+    </DattaModal>
+  );
+}

--- a/src/renderer/components/common/DattaDateRangePicker.jsx
+++ b/src/renderer/components/common/DattaDateRangePicker.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export default function DattaDateRangePicker({ start, end, onChange }) {
+  const handleStart = (e) => onChange({ start: e.target.value, end });
+  const handleEnd = (e) => onChange({ start, end: e.target.value });
+
+  return (
+    <div className="d-flex align-items-center gap-2">
+      <input type="date" className="form-control" value={start} onChange={handleStart} />
+      <span className="mx-2">-</span>
+      <input type="date" className="form-control" value={end} onChange={handleEnd} />
+    </div>
+  );
+}

--- a/src/renderer/components/common/DattaDiagnosticPanel.jsx
+++ b/src/renderer/components/common/DattaDiagnosticPanel.jsx
@@ -1,0 +1,61 @@
+import React, { useState, useEffect } from 'react';
+import DattaCard from './DattaCard';
+import DattaButton from './DattaButton';
+
+export default function DattaDiagnosticPanel() {
+  const [diagnostics, setDiagnostics] = useState({});
+  const [isRunning, setIsRunning] = useState(false);
+
+  const runDiagnostics = async () => {
+    setIsRunning(true);
+    try {
+      const results = await window.api.runDiagnostics();
+      setDiagnostics(results);
+    } catch (error) {
+      setDiagnostics({ error: error.message });
+    } finally {
+      setIsRunning(false);
+    }
+  };
+
+  return (
+    <DattaCard
+      title="Diagnostics systeme"
+      actions={
+        <DattaButton variant="primary" size="sm" onClick={runDiagnostics} loading={isRunning}>
+          <i className="feather icon-play me-2"></i>
+          Lancer diagnostic
+        </DattaButton>
+      }
+    >
+      <div className="row">
+        <div className="col-md-6">
+          <h6><i className="feather icon-database me-2"></i>Base de donnees</h6>
+          <ul className="list-unstyled">
+            <li className="d-flex justify-content-between">
+              <span>Connexion</span>
+              <span className={`badge bg-${diagnostics.dbConnection ? 'success' : 'danger'}`}>{diagnostics.dbConnection ? 'OK' : 'Echec'}</span>
+            </li>
+            <li className="d-flex justify-content-between">
+              <span>Temps de reponse</span>
+              <span className="badge bg-info">{diagnostics.dbLatency}ms</span>
+            </li>
+          </ul>
+        </div>
+        <div className="col-md-6">
+          <h6><i className="feather icon-wifi me-2"></i>Reseau</h6>
+          <ul className="list-unstyled">
+            <li className="d-flex justify-content-between">
+              <span>Partage accessible</span>
+              <span className={`badge bg-${diagnostics.networkShare ? 'success' : 'danger'}`}>{diagnostics.networkShare ? 'OK' : 'Echec'}</span>
+            </li>
+            <li className="d-flex justify-content-between">
+              <span>Permissions</span>
+              <span className={`badge bg-${diagnostics.permissions ? 'success' : 'warning'}`}>{diagnostics.permissions ? 'Lecture/Ecriture' : 'Lecture seule'}</span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </DattaCard>
+  );
+}

--- a/src/renderer/components/common/DattaErrorBoundary.jsx
+++ b/src/renderer/components/common/DattaErrorBoundary.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import DattaButton from './DattaButton';
+
+class DattaErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true, error };
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="d-flex justify-content-center align-items-center min-vh-100">
+          <div className="card text-center" style={{ maxWidth: '500px' }}>
+            <div className="card-body">
+              <div className="avtar avtar-xl bg-light-danger mb-4">
+                <i className="feather icon-alert-triangle f-36"></i>
+              </div>
+              <h4 className="mb-3">Oups ! Une erreur s'est produite</h4>
+              <p className="text-muted mb-4">L'application a rencontre un probleme. Vos donnees sont sauvegardees.</p>
+              <div className="d-flex gap-2 justify-content-center">
+                <DattaButton variant="primary" onClick={() => window.location.reload()}>Recharger l'application</DattaButton>
+                <DattaButton variant="secondary" onClick={() => this.setState({ hasError: false })}>Reessayer</DattaButton>
+              </div>
+            </div>
+          </div>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+export default DattaErrorBoundary;

--- a/src/renderer/components/common/DattaFileDropzone.jsx
+++ b/src/renderer/components/common/DattaFileDropzone.jsx
@@ -1,0 +1,23 @@
+import React, { useCallback } from 'react';
+
+export default function DattaFileDropzone({ onFiles }) {
+  const handleDrop = useCallback((e) => {
+    e.preventDefault();
+    const files = Array.from(e.dataTransfer.files);
+    onFiles(files);
+  }, [onFiles]);
+
+  const prevent = (e) => e.preventDefault();
+
+  return (
+    <div
+      onDragOver={prevent}
+      onDragEnter={prevent}
+      onDrop={handleDrop}
+      className="border border-dashed p-3 text-center"
+      style={{ cursor: 'pointer' }}
+    >
+      Glisser les fichiers ici
+    </div>
+  );
+}

--- a/src/renderer/components/common/DattaLoadingOverlay.jsx
+++ b/src/renderer/components/common/DattaLoadingOverlay.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+export default function DattaLoadingOverlay({ isLoading, message = "Chargement...", progress = null, children }) {
+  return (
+    <div className="position-relative">
+      {children}
+      {isLoading && (
+        <div className="position-absolute top-0 start-0 w-100 h-100 d-flex flex-column align-items-center justify-content-center bg-white bg-opacity-75">
+          <div className="spinner-border text-primary mb-3" role="status">
+            <span className="visually-hidden">Loading...</span>
+          </div>
+          <h6 className="mb-2">{message}</h6>
+          {progress !== null && (
+            <div className="progress" style={{ width: '200px' }}>
+              <div className="progress-bar" style={{ width: `${progress}%` }}></div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/renderer/components/common/DattaMultiSelect.jsx
+++ b/src/renderer/components/common/DattaMultiSelect.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+export default function DattaMultiSelect({ options = [], value = [], onChange }) {
+  const toggleValue = (val) => {
+    if (value.includes(val)) {
+      onChange(value.filter(v => v !== val));
+    } else {
+      onChange([...value, val]);
+    }
+  };
+
+  return (
+    <div className="d-flex flex-wrap gap-2">
+      {options.map(opt => (
+        <label key={opt.value} className="form-check-label">
+          <input
+            type="checkbox"
+            className="form-check-input me-1"
+            checked={value.includes(opt.value)}
+            onChange={() => toggleValue(opt.value)}
+          />
+          {opt.label}
+        </label>
+      ))}
+    </div>
+  );
+}

--- a/src/renderer/components/common/DattaNetworkDataTable.jsx
+++ b/src/renderer/components/common/DattaNetworkDataTable.jsx
@@ -1,0 +1,63 @@
+import React, { useState, useEffect } from 'react';
+import DattaDataTable from './DattaDataTable';
+import DattaAlert from './DattaAlert';
+
+export default function DattaNetworkDataTable({ onLoadData, retryInterval = 5000, ...props }) {
+  const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [retryCount, setRetryCount] = useState(0);
+
+  const loadData = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const result = await onLoadData();
+      setData(result);
+      setRetryCount(0);
+    } catch (err) {
+      setError(err.message);
+      setRetryCount(prev => prev + 1);
+      if (retryCount < 3) {
+        setTimeout(loadData, retryInterval * Math.pow(2, retryCount));
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadData();
+  }, []);
+
+  if (error && retryCount >= 3) {
+    return (
+      <div className="card">
+        <div className="card-body text-center">
+          <DattaAlert type="danger">
+            <i className="feather icon-wifi-off me-2"></i>
+            Impossible de charger les donnees. Verifiez votre connexion reseau.
+          </DattaAlert>
+          <button className="btn btn-primary" onClick={loadData}>
+            <i className="feather icon-refresh-cw me-2"></i>
+            Reessayer
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <DattaDataTable
+      {...props}
+      data={data}
+      loading={loading}
+      actions={
+        <div className="d-flex align-items-center gap-2">
+          {props.actions}
+          {loading && <div className="spinner-border spinner-border-sm" role="status"></div>}
+        </div>
+      }
+    />
+  );
+}

--- a/src/renderer/components/common/DattaNetworkStatus.jsx
+++ b/src/renderer/components/common/DattaNetworkStatus.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import DattaAlert from './DattaAlert';
+
+export default function DattaNetworkStatus({ isOnline, lastSync }) {
+  if (!isOnline) {
+    return (
+      <DattaAlert type="warning" className="fixed-top m-3">
+        <i className="feather icon-wifi-off me-2"></i>
+        Reseau indisponible - Mode hors ligne
+      </DattaAlert>
+    );
+  }
+  return (
+    <div className="badge bg-success">
+      <i className="feather icon-wifi me-1"></i>
+      Connecte
+    </div>
+  );
+}

--- a/src/renderer/components/common/DattaNotificationCenter.jsx
+++ b/src/renderer/components/common/DattaNotificationCenter.jsx
@@ -1,0 +1,42 @@
+import React, { useState, useEffect } from 'react';
+import DattaAlert from './DattaAlert';
+
+export default function DattaNotificationCenter() {
+  const [notifications, setNotifications] = useState([]);
+
+  const addNotification = (notification) => {
+    const id = Date.now();
+    setNotifications(prev => [...prev, { ...notification, id }]);
+    if (notification.autoClose !== false) {
+      setTimeout(() => removeNotification(id), notification.duration || 5000);
+    }
+  };
+
+  const removeNotification = (id) => {
+    setNotifications(prev => prev.filter(n => n.id !== id));
+  };
+
+  useEffect(() => {
+    window.showNotification = addNotification;
+    return () => {
+      delete window.showNotification;
+    };
+  }, []);
+
+  return (
+    <div className="position-fixed top-0 end-0 p-3" style={{ zIndex: 9999 }}>
+      {notifications.map(notification => (
+        <DattaAlert
+          key={notification.id}
+          type={notification.type}
+          dismissible
+          onClose={() => removeNotification(notification.id)}
+          className="mb-2 shadow"
+        >
+          {notification.icon && <i className={`feather ${notification.icon} me-2`}></i>}
+          {notification.message}
+        </DattaAlert>
+      ))}
+    </div>
+  );
+}

--- a/src/renderer/components/common/DattaOperationStatus.jsx
+++ b/src/renderer/components/common/DattaOperationStatus.jsx
@@ -1,0 +1,21 @@
+export default function DattaOperationStatus({ operations }) {
+  if (operations.length === 0) return null;
+  return (
+    <div className="fixed-bottom p-3">
+      <div className="card shadow">
+        <div className="card-body">
+          <h6><i className="feather icon-activity me-2"></i>Operations en cours</h6>
+          {operations.map(op => (
+            <div key={op.id} className="d-flex align-items-center mb-2">
+              <div className="spinner-border spinner-border-sm me-2" role="status"></div>
+              <span className="me-auto">{op.description}</span>
+              <div className="progress" style={{ width: '100px' }}>
+                <div className="progress-bar" style={{ width: `${op.progress}%` }}></div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/common/DattaPasswordStrength.jsx
+++ b/src/renderer/components/common/DattaPasswordStrength.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+export default function DattaPasswordStrength({ value = '' }) {
+  const calcStrength = () => {
+    let score = 0;
+    if (value.length >= 8) score++;
+    if (/[A-Z]/.test(value)) score++;
+    if (/[0-9]/.test(value)) score++;
+    if (/[^A-Za-z0-9]/.test(value)) score++;
+    return score;
+  };
+
+  const score = calcStrength();
+  const labels = ['Faible', 'Moyen', 'Bon', 'Fort'];
+  const colors = ['danger', 'warning', 'info', 'success'];
+
+  return (
+    <div className="mt-1">
+      <div className="progress" style={{ height: '6px' }}>
+        <div className={`progress-bar bg-${colors[score - 1] || 'danger'}`} style={{ width: `${(score / 4) * 100}%` }}></div>
+      </div>
+      <small className={`text-${colors[score - 1] || 'danger'}`}>{labels[score - 1] || labels[0]}</small>
+    </div>
+  );
+}

--- a/src/renderer/components/common/DattaProgressTracker.jsx
+++ b/src/renderer/components/common/DattaProgressTracker.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export default function DattaProgressTracker({ steps = [], current = 0 }) {
+  return (
+    <ol className="list-unstyled d-flex gap-3">
+      {steps.map((step, idx) => (
+        <li key={step} className={`badge ${idx <= current ? 'bg-primary' : 'bg-secondary'}`}>{step}</li>
+      ))}
+    </ol>
+  );
+}

--- a/src/renderer/components/common/DattaSecurityAlert.jsx
+++ b/src/renderer/components/common/DattaSecurityAlert.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import DattaAlert from './DattaAlert';
+
+export default function DattaSecurityAlert({ message }) {
+  return (
+    <DattaAlert type="danger">
+      <i className="feather icon-shield me-2"></i>
+      {message}
+    </DattaAlert>
+  );
+}

--- a/src/renderer/styles/themes.css
+++ b/src/renderer/styles/themes.css
@@ -225,3 +225,10 @@
     grid-template-columns: 1fr;
   }
 }
+
+[data-theme="dark"] {
+  --pc-bg-color: #1a1a1a;
+  --pc-card-bg: #2d2d2d;
+  --pc-text-color: #ffffff;
+  --pc-border-color: #404040;
+}


### PR DESCRIPTION
## Summary
- implement Datta UI helpers from todo
- add dark theme support to `themes.css`

## Testing
- `npm run build` *(fails: `npm: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_6846a213c4348326b69ce205db7bc0aa