### PR TITLE
Use libsql Builder API

### DIFF
--- a/src-tauri/src/database/connection.rs
+++ b/src-tauri/src/database/connection.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use std::sync::Arc;
-use libsql::{Database, Connection};
+use libsql::{Builder, Database, Connection};
 
 pub struct DatabasePool {
     db: Arc<Database>,
@@ -8,7 +8,10 @@ pub struct DatabasePool {
 
 impl DatabasePool {
     pub async fn new_network_optimized(db_path: &str) -> Result<Self> {
-        let db = Database::open_remote(db_path, "").context("Impossible d'ouvrir la base")?;
+        let db = Builder::new_remote(db_path.to_string(), "".to_string())
+            .build()
+            .await
+            .context("Impossible d'ouvrir la base")?;
         let conn = db.connect()?;
         conn.execute(
             "PRAGMA journal_mode=WAL",

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -22,7 +22,7 @@ async fn main() {
                 .join("db")
                 .join("ottercms.sqlite");
             
-            // Pour libsql 0.6.0, Database::open est synchrone
+            // Depuis libsql 0.6.0, l'ouverture via Builder est asynchrone
             let pool = block_on(DatabasePool::new_network_optimized(db_path.to_str().unwrap()))
                 .expect("failed to open database");
             


### PR DESCRIPTION
## Summary
- migrate deprecated `open_remote` call to the new `Builder` pattern
- adjust comment in `main.rs` accordingly

## Testing
- `cargo check` *(fails: `glib-2.0` system library missing)*

------
https://chatgpt.com/codex/tasks/task_b_6847114e01f48326bb292858d54b05f8