### PR TITLE
Fix SQLite connection builder

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -12,7 +12,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.40", features = ["full"] }
 # Utiliser libsql avec sqlite bundled pour éviter la compilation native
-libsql = { version = "0.6.0", features = ["remote", "tls"], default-features = false }
+libsql = { version = "0.6.0", features = ["core", "remote", "tls"], default-features = false }
 sysinfo = "0.31"
 anyhow = "1.0"
 futures = "0.3"

--- a/src-tauri/src/database/connection.rs
+++ b/src-tauri/src/database/connection.rs
@@ -8,7 +8,9 @@ pub struct DatabasePool {
 
 impl DatabasePool {
     pub async fn new_network_optimized(db_path: &str) -> Result<Self> {
-        let db = Builder::new_remote(db_path.to_string(), "".to_string())
+        // Use a local SQLite connection since the database is a local file
+        // rather than a remote libSQL server
+        let db = Builder::new_local(db_path.to_string())
             .build()
             .await
             .context("Impossible d'ouvrir la base")?;


### PR DESCRIPTION
## Summary
- use `new_local` for local database connections
- enable the `core` feature so libsql provides the local builder

## Testing
- `cargo check` *(fails: missing `javascriptcoregtk-4.1` and `libsoup-3.0` system libraries)*

------
https://chatgpt.com/codex/tasks/task_b_684718b7a510832685cf909ded398c97