### PR TITLE
Fix unused parameter warning

### DIFF
--- a/src-tauri/src/commands/diagnostics.rs
+++ b/src-tauri/src/commands/diagnostics.rs
@@ -32,7 +32,7 @@ fn get_system_and_disks() -> (System, Disks) {
 }
 
 #[tauri::command]
-pub async fn ping_database(app: AppHandle) -> Result<DiagnosticResult, String> {
+pub async fn ping_database(_app: AppHandle) -> Result<DiagnosticResult, String> {
     let start = std::time::Instant::now();
     let db_path = "../db/ottercms.sqlite";
     let connected = fs::metadata(db_path).is_ok();


### PR DESCRIPTION
## Summary
- suppress unused parameter warning in diagnostics command

## Testing
- `cargo check` *(fails: glib-sys build script can't find glib-2.0)*

------
https://chatgpt.com/codex/tasks/task_b_68473f63784883268294c4c81df4fb8e