### PR TITLE
Implement Oracle backend commands

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -14,6 +14,7 @@ tokio = { version = "1.40", features = ["full"] }
 tauri-plugin-sql = { version = "2.0", features = ["sqlite"] }
 sysinfo = "0.31"
 chrono = { version = "0.4", features = ["serde"] }
+oracle = "0.6"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["winbase"] }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,2 +1,3 @@
 pub mod diagnostics;
 pub mod config;
+pub mod oracle;

--- a/src-tauri/src/commands/oracle.rs
+++ b/src-tauri/src/commands/oracle.rs
@@ -1,0 +1,102 @@
+use serde::{Serialize, Deserialize};
+use serde_json::json;
+use oracle::*;
+use std::fs::{self, OpenOptions};
+use std::path::PathBuf;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OracleConfig {
+    pub host: String,
+    pub port: u16,
+    pub service_name: String,
+    pub username: String,
+    pub password: String,
+}
+
+fn get_connect_string(cfg: &OracleConfig) -> String {
+    format!("{}:{}/{}", cfg.host, cfg.port, cfg.service_name)
+}
+
+#[tauri::command]
+pub async fn test_oracle_connection(cfg: OracleConfig) -> Result<serde_json::Value, String> {
+    let conn_str = get_connect_string(&cfg);
+    let res = tokio::task::spawn_blocking(move || Connection::connect(cfg.username, cfg.password, conn_str));
+    match res.await {
+        Ok(Ok(conn)) => {
+            let _ = conn.close();
+            Ok(json!({"success": true, "message": "Connexion réussie"}))
+        }
+        Ok(Err(e)) => Ok(json!({"success": false, "error": e.to_string()})),
+        Err(e) => Ok(json!({"success": false, "error": e.to_string()})),
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QueryData {
+    pub meta_data: Vec<String>,
+    pub rows: Vec<Vec<String>>,
+}
+
+#[tauri::command]
+pub async fn execute_oracle_query(cfg: OracleConfig, query: String, max_rows: Option<usize>) -> Result<serde_json::Value, String> {
+    let conn_str = get_connect_string(&cfg);
+    let max_rows = max_rows.unwrap_or(1000);
+    let res = tokio::task::spawn_blocking(move || {
+        let conn = Connection::connect(cfg.username, cfg.password, conn_str)?;
+        let mut stmt = conn.prepare(&query, &[])?;
+        let rows = stmt.query(&[])?;
+        let mut data = Vec::new();
+        for row_result in rows.fetch_many()? {
+            if data.len() >= max_rows { break; }
+            let row = row_result?;
+            let mut values = Vec::new();
+            for col in row.columns() {
+                let val: Option<String> = row.get(col.name())?;
+                values.push(val.unwrap_or_default());
+            }
+            data.push(values);
+        }
+        let meta = stmt.column_info().iter().map(|c| c.name().to_string()).collect();
+        Ok::<_, oracle::Error>(QueryData { meta_data: meta, rows: data })
+    }).await;
+    match res {
+        Ok(Ok(d)) => Ok(json!({"success": true, "data": d})),
+        Ok(Err(e)) => Ok(json!({"success": false, "error": e.to_string()})),
+        Err(e) => Ok(json!({"success": false, "error": e.to_string()})),
+    }
+}
+
+const CONFIG_FILE: &str = "../config/oracle_configs.json";
+
+fn read_configs() -> Vec<serde_json::Value> {
+    let path = PathBuf::from(CONFIG_FILE);
+    if let Ok(data) = fs::read_to_string(&path) {
+        if let Ok(v) = serde_json::from_str(&data) {
+            return v;
+        }
+    }
+    Vec::new()
+}
+
+fn write_configs(cfgs: &[serde_json::Value]) -> std::io::Result<()> {
+    let path = PathBuf::from(CONFIG_FILE);
+    if let Some(parent) = path.parent() { fs::create_dir_all(parent)?; }
+    fs::write(path, serde_json::to_string_pretty(cfgs).unwrap())
+}
+
+#[tauri::command]
+pub async fn get_oracle_configs() -> Result<serde_json::Value, String> {
+    let data = read_configs();
+    Ok(json!({"success": true, "data": data}))
+}
+
+#[tauri::command]
+pub async fn save_oracle_config(cfg: serde_json::Value) -> Result<serde_json::Value, String> {
+    let mut all = read_configs();
+    all.push(cfg);
+    write_configs(&all).map_err(|e| e.to_string())?;
+    Ok(json!({"success": true}))
+}
+

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -8,6 +8,10 @@ async fn main() {
             commands::diagnostics::ping_database,
             commands::diagnostics::run_diagnostics,
             commands::config::get_db_path,
+            commands::oracle::test_oracle_connection,
+            commands::oracle::execute_oracle_query,
+            commands::oracle::get_oracle_configs,
+            commands::oracle::save_oracle_config,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -9,7 +9,7 @@
   },
   "plugins": {
     "sql": {
-      "preload": []
+      "preload": ["../src/preload/index.js"]
     }
   },
   "app": {

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -1,0 +1,13 @@
+import { invoke } from '@tauri-apps/api/core';
+
+window.api = {
+  testOracleConnection: (cfg) => invoke('test_oracle_connection', { cfg }),
+  executeOracleQuery: (params) => invoke('execute_oracle_query', {
+    cfg: params.config,
+    query: params.query,
+    maxRows: params.maxRows,
+  }),
+  getOracleConfigs: () => invoke('get_oracle_configs'),
+  saveOracleConfig: (cfg) => invoke('save_oracle_config', { cfg }),
+};
+


### PR DESCRIPTION
## Summary
- implement Oracle backend commands in Rust
- expose Oracle commands via preload script
- register commands in Tauri and add preload path
- update dependencies for Oracle support

## Testing
- `npm run audit` *(fails: This command requires an existing lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_6848484f3eb4832680a3cf2680fb1880